### PR TITLE
Refactor movement code.

### DIFF
--- a/DogTales/src/dogtales.cpp
+++ b/DogTales/src/dogtales.cpp
@@ -9,7 +9,7 @@ void DogTales::tick() {
 }
 
 void DogTales::render() const {
-	set_viewport_to_world_space(); // stretch sprites to fit the framebuffer, fixed sized world space
+	set_viewport_to_world_space(); // stretch sprites to fit the fixed sized world space.
 
 	if (auto shader = get_app().load_shader("shaders/default.vert", "shaders/default.frag")) { m_player.draw(*shader); }
 }

--- a/DogTales/src/dogtales.cpp
+++ b/DogTales/src/dogtales.cpp
@@ -1,34 +1,23 @@
 #include <src/dogtales.hpp>
 
-DogTales::DogTales(bave::App& app) : bave::Driver(app), m_render_buffer_size({1280, 720}) {
-	m_player = Player{&get_app()};
-}
+DogTales::DogTales(bave::App& app) : bave::Driver(app) {}
 
 void DogTales::tick() {
 	auto const dt = get_app().get_dt();
 
-	m_player->tick(dt);
+	m_player.tick(dt);
 }
 
 void DogTales::render() const {
-	set_viewport_to_fixed_buffer();   // stretch sprites to fit the framebuffer, fixed sized world space
+	set_viewport_to_world_space(); // stretch sprites to fit the framebuffer, fixed sized world space
 
-	if (auto shader = get_app().load_shader("shaders/default.vert", "shaders/default.frag")) {
-		m_player->draw(*shader);
-	}
+	if (auto shader = get_app().load_shader("shaders/default.vert", "shaders/default.frag")) { m_player.draw(*shader); }
 }
 
 void DogTales::on_key(bave::KeyInput const& key_input) {
-	if (key_input.key == bave::Key::eEscape && key_input.action == bave::Action::eRelease) {
-		get_app().shutdown();
-	}
+	if (key_input.key == bave::Key::eEscape && key_input.action == bave::Action::eRelease) { get_app().shutdown(); }
 }
 
-void DogTales::set_viewport_to_window_size() const {
-	get_app().get_render_device().render_view.viewport = get_app().get_window_size();
+void DogTales::set_viewport_to_world_space() const {
+	get_app().get_render_device().render_view.viewport = world_space_v;
 }
-
-void DogTales::set_viewport_to_fixed_buffer() const {
-	get_app().get_render_device().render_view.viewport = m_render_buffer_size;
-}
-

--- a/DogTales/src/dogtales.hpp
+++ b/DogTales/src/dogtales.hpp
@@ -3,16 +3,16 @@
 #include <src/player.hpp>
 
 class DogTales : public bave::Driver {
-	std::optional<Player> m_player{};
-	glm::vec2 m_render_buffer_size{};
+	static constexpr glm::vec2 world_space_v{1280.0f, 720.0f};
+
+	Player m_player{world_space_v};
 
 	void tick() final;
 	void render() const final;
 
 	void on_key(bave::KeyInput const& key_input) final;
 
-	void set_viewport_to_window_size() const;
-	void set_viewport_to_fixed_buffer() const;
+	void set_viewport_to_world_space() const;
 
   public:
 	explicit DogTales(bave::App& app);

--- a/DogTales/src/player.cpp
+++ b/DogTales/src/player.cpp
@@ -1,56 +1,26 @@
 #include <src/player.hpp>
 
-Player::Player(bave::NotNull<bave::App const*> app) 
-	: m_app(app), m_sprite(), m_vel(PLAYER_SPEED), 
-	  m_isTouchingGround(false), 
-	  m_isMovingLeft(false), m_isMovingRight(false), 
-	  m_isMovingUp(false), m_isMovingDown(false) {
-	m_sprite.set_texture({});
-	m_sprite.set_size({50.0f, 90.0f});
+Player::Player(glm::vec2 const world_space) : m_world_space(world_space) { m_sprite.set_size(size_v); }
+
+void Player::tick(bave::Seconds const dt) {
+	m_sprite.transform.position += m_vel * dt.count();
+
+	handle_wall_collision();
 }
 
-void Player::tick(bave::Seconds dt) {
-    m_sprite.transform.position += m_vel * dt.count();
+void Player::draw(bave::Shader& shader) const { m_sprite.draw(shader); }
 
-    HandleWallCollision();
-}
+void Player::handle_wall_collision() {
+	auto& position = m_sprite.transform.position;
+	// bounce_rect represents the play area for the sprite, ie the limits for its centre.
+	// this is simply the total space minus the sprite size.
+	auto const bounce_rect = bave::Rect<>::from_size(m_world_space - m_sprite.get_size());
 
-void Player::draw(bave::Shader& shader) const { 
-	m_sprite.draw(shader);
-}
+	// if the sprite's position exceeds the play area, the corresponding velocity component needs to flip.
+	if (position.x < bounce_rect.top_left().x || position.x > bounce_rect.bottom_right().x) { m_vel.x *= -1.0f; }
+	if (position.y > bounce_rect.top_left().y || position.y < bounce_rect.bottom_right().y) { m_vel.y *= -1.0f; }
 
-void Player::HandleWallCollision() {
-	const glm::vec2 sprite_size = m_sprite.get_size() / 2.0f;
-	const glm::vec2 frame_size = m_app->get_framebuffer_size() / 2;
-
-	HandleLeftRightWallCollision(sprite_size.x, frame_size.x);
-	HandleTopBottomWallCollision(sprite_size.y, frame_size.y);
-}
-
-void Player::HandleLeftRightWallCollision(const float sprite_width, const float frame_width) {
-	const float left_bound  = sprite_width - frame_width;
-	const float right_bound = frame_width  - sprite_width;
-
-	float& sprite_pos_x = m_sprite.transform.position.x;
-	if (sprite_pos_x < left_bound) {
-		sprite_pos_x += left_bound - sprite_pos_x; 
-		m_vel.x *= -1.0f;
-	} else if (sprite_pos_x > right_bound) {
-		sprite_pos_x -= sprite_pos_x - right_bound; 
-		m_vel.x *= -1.0f;
-	}
-}
-
-void Player::HandleTopBottomWallCollision(const float sprite_height, const float frame_height) {
-	const float top_bound    = frame_height  - sprite_height;
-	const float bottom_bound = sprite_height - frame_height;
-
-	float& sprite_pos_y = m_sprite.transform.position.y;
-	if (sprite_pos_y > top_bound) {
-		sprite_pos_y -= sprite_pos_y - top_bound; 
-		m_vel.y *= -1.0f;
-	} else if (sprite_pos_y < bottom_bound) {
-		sprite_pos_y += bottom_bound - sprite_pos_y; 
-		m_vel.y *= -1.0f;
-	}
+	// clamp the position to the play area.
+	// bottom_left() gives us the minimum x and y whereas top_right() gives us the maximum.
+	position = glm::clamp(position, bounce_rect.bottom_left(), bounce_rect.top_right());
 }

--- a/DogTales/src/player.cpp
+++ b/DogTales/src/player.cpp
@@ -13,8 +13,9 @@ void Player::draw(bave::Shader& shader) const { m_sprite.draw(shader); }
 void Player::handle_wall_collision() {
 	auto& position = m_sprite.transform.position;
 	// bounce_rect represents the play area for the sprite, ie the limits for its centre.
-	// this is simply the total space minus the sprite size.
-	auto const bounce_rect = bave::Rect<>::from_size(m_world_space - m_sprite.get_size());
+	// the size is simply the total space minus the sprite size, centered at the origin.
+	// the second argument (glm::vec2{0.0f}) is the default value and can be omitted here.
+	auto const bounce_rect = bave::Rect<>::from_size(m_world_space - m_sprite.get_size(), glm::vec2{0.0f});
 
 	// if the sprite's position exceeds the play area, the corresponding velocity component needs to flip.
 	if (position.x < bounce_rect.top_left().x || position.x > bounce_rect.bottom_right().x) { m_vel.x *= -1.0f; }

--- a/DogTales/src/player.hpp
+++ b/DogTales/src/player.hpp
@@ -1,37 +1,21 @@
 #pragma once
 #include <bave/app.hpp>
-//#include <bave/graphics/shape.hpp>
 #include <bave/graphics/sprite.hpp>
 
-enum class Direction {
-	UP,
-	DOWN,
-	LEFT,
-	RIGHT
-};
-
-constexpr glm::vec2 PLAYER_SPEED { 500.0f, 500.0f };
-
 class Player {
-    bave::NotNull<bave::App const*> m_app;
+	static constexpr glm::vec2 speed_v{500.0f, 500.0f};
+	static constexpr glm::vec2 size_v{50.0f, 90.0f};
+
+	glm::vec2 m_world_space{};
 
 	bave::Sprite m_sprite{};
 
-	glm::vec2 m_vel{};
+	glm::vec2 m_vel{speed_v};
 
-	bool m_isTouchingGround{};
-
-	bool m_isMovingLeft{};
-	bool m_isMovingRight{};
-	bool m_isMovingUp{};
-	bool m_isMovingDown{};
-
-	void HandleWallCollision();
-	void HandleLeftRightWallCollision(const float sprite_width, const float frame_width);
-	void HandleTopBottomWallCollision(const float sprite_height, const float frame_height);
+	void handle_wall_collision();
 
   public:
-	explicit Player(bave::NotNull<bave::App const*> app);
+	explicit Player(glm::vec2 world_space);
 
 	void tick(bave::Seconds dt);
 	void draw(bave::Shader& shader) const;


### PR DESCRIPTION
Summary:
- Format all modified files.
- Use consistent casing for functions.
- Use constants where warranted.
- Store `world_space` in `Player` instead of `App*`.
- Store `Player` in `DogTales` instead of `optional<Player>`.
- Simplify bounce detection and resolution.

This also takes care of bouncing correctly when the window is resized.

Note: this PR _does not_ target `main` but `Jake/Movement+KeyInput`.