### PR TITLE
Add code format check as GitHub workflow.

### DIFF
--- a/.github/format_check_diff.sh
+++ b/.github/format_check_diff.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+[[ ! $(git --version) ]] && exit 1
+
+output=$(git diff)
+
+if [[ "$output" != "" ]]; then
+  echo "One or more source files are not formatted!"
+  exit 1
+fi
+
+echo "All source files are formatted"
+exit

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -1,0 +1,11 @@
+name: format-check
+on: [push]
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: format code
+        run: tools/format_code.sh
+      - name: check diff
+        run: .github/format_check_diff.sh

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -1,4 +1,4 @@
-name: format-check
+name: ci
 on: [push]
 jobs:
   format-check:

--- a/DogTales/src/components/physics.cpp
+++ b/DogTales/src/components/physics.cpp
@@ -5,7 +5,9 @@ namespace component {
 void Physics::tick(bave::Seconds dt) {
 	static constexpr bave::Seconds ft{0.005}; // 5ms
 
-	if (dt.count() > tick_limit_v.count()) { return; } // return for unexpected dt values, particularly during the beginning of the state
+	if (dt.count() > tick_limit_v.count()) {
+		return;
+	} // return for unexpected dt values, particularly during the beginning of the state
 
 	for (dt += m_residue; dt > ft; dt -= ft) { integrate(ft); }
 	m_residue = dt;

--- a/DogTales/src/components/physics.hpp
+++ b/DogTales/src/components/physics.hpp
@@ -16,8 +16,8 @@ class Physics {
 	bave::Seconds m_residue{};
 
   public:
-
-	Physics(glm::vec2 friction = default_friction, float gravity = default_gravity, float mass = default_mass) : friction(friction), gravity(gravity), mass(mass) {}
+	Physics(glm::vec2 friction = default_friction, float gravity = default_gravity, float mass = default_mass)
+		: friction(friction), gravity(gravity), mass(mass) {}
 
 	glm::vec2 position{};
 	glm::vec2 velocity{};

--- a/DogTales/src/player.cpp
+++ b/DogTales/src/player.cpp
@@ -21,8 +21,12 @@ void Player::handle_wall_collision() {
 	auto const bounce_rect = bave::Rect<>::from_size(m_world_space - m_sprite.get_size(), glm::vec2{0.0f});
 
 	// if the sprite's position exceeds the play area, the corresponding velocity component needs to flip.
-	if (position.x < bounce_rect.top_left().x || position.x > bounce_rect.bottom_right().x) { m_physics.velocity.x *= -0.9f; }
-	if (position.y > bounce_rect.top_left().y || position.y < bounce_rect.bottom_right().y) { m_physics.velocity.y *= -0.9f; }
+	if (position.x < bounce_rect.top_left().x || position.x > bounce_rect.bottom_right().x) {
+		m_physics.velocity.x *= -0.9f;
+	}
+	if (position.y > bounce_rect.top_left().y || position.y < bounce_rect.bottom_right().y) {
+		m_physics.velocity.y *= -0.9f;
+	}
 
 	// clamp the position to the play area.
 	// bottom_left() gives us the minimum x and y whereas top_right() gives us the maximum.

--- a/tools/format_code.sh
+++ b/tools/format_code.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+[[ ! $(clang-format --version) ]] && exit 1
+
+script_path=${0%/*}
+tools_root=${script_path%/*}
+project_root=$tools_root/..
+
+if [[ "$0" != "$project_root" ]] && [[ "$project_root" != "" ]]; then
+  cd "$project_root" || exit 1
+  echo "-- Changed pwd to $(pwd)"
+fi
+
+files=$(find DogTales -name "*.?pp")
+if [[ "$files" == "" ]]; then
+  echo "-- No source files found"
+  exit
+fi
+
+clang-format -i $files
+echo -e "-- Formatted Files:\n$files\n"
+
+exit


### PR DESCRIPTION
Adds `tools/format_code.sh` which runs `clang-format` on all source files in `DogTales/`.
Note: On Windows this will need to be run in git bash.

Also adds a GitHub workflow - `format-check`, which runs the script above and fails if it results in modified files.

The first commit demonstrates such a failure, the next commit fixes it.

Once this is merged into `main`, `format-check` will be made a required check for PR merges.

Note: click "Show all checks" on a PR to expand the list, if it is collapsed.

![Screenshot_20240202_153136](https://github.com/cpp-gamedev/DogTales/assets/16272243/a476c2f7-9a36-42af-ae51-127ffccc1172)

![Screenshot_20240202_153207](https://github.com/cpp-gamedev/DogTales/assets/16272243/d6740b8f-0450-4693-916b-9dbb8ad91a86)

![Screenshot_20240202_153249](https://github.com/cpp-gamedev/DogTales/assets/16272243/ae71d98f-7a9e-4c17-80eb-d3cc9691eba2)
